### PR TITLE
No highlight in context menu, change  --item-hover-bg-color to  --bg-…

### DIFF
--- a/theme/notes-dark.css
+++ b/theme/notes-dark.css
@@ -47,7 +47,7 @@
   --meta-content-color: var(--primary-color);
   --primary-btn-border-color: var(--primary-color);
   --side-bar-bg-color: var(--bg-color-dark);
-  --item-hover-bg-color: var(--bg-color);
+  --item-hover-bg-color: var(--bg-color-dark);
   --active-file-bg-color: var(--bg-color);
   --active-file-border-color: var(--bg-color);
   --window-border: 1px solid var(--bg-color);


### PR DESCRIPTION
…color-dark

When hover the contexts menus items are not highlighted. This happens because the two states have same color for background 
The highlight is useful for example when one call context menu using the keyboard  for do spell checking replacements